### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cs_util"
-version = "0.2"
+version = "0.2.1"
 description = "Utility library for CosmoStat"
 authors = [
 	{ name = "Martin Kilbinger", email = "martin.kilbinger@cea.fr" },


### PR DESCRIPTION
Version bump for the first release containing `cs_util.size` (#65). The published PyPI 0.2 predates the size module, so a fresh version is required for downstream pins (sp_validation will pin `cs_util>=0.2.1`).

— Claude on behalf of Cail